### PR TITLE
Fixed broken links in “How To Install archiveweb.page” documentation

### DIFF
--- a/_en/install.md
+++ b/_en/install.md
@@ -17,7 +17,7 @@ Installing archiveweb.page is similar to installation any other Chrome extension
 3. <b>Pin it:</b> to your extensions bar
 
 ## INSTRUCTIONS (WITH IMAGES)
-1. <b>[Find archiveweb.page in the Chrome store](installation/chromestore)</b>
+1. <b>[Find archiveweb.page in the Chrome store](installation/install_requirements)</b>
 2. <b>[Add archiveweb.page to your Chrome](installation/add_extension)</b>
 3. <b>[Pin archiveweb.page to your Chrome extensions](installation/pin_extension)</b> 
 

--- a/_en/install.md
+++ b/_en/install.md
@@ -17,9 +17,9 @@ Installing archiveweb.page is similar to installation any other Chrome extension
 3. <b>Pin it:</b> to your extensions bar
 
 ## INSTRUCTIONS (WITH IMAGES)
-1. <b>[Find archiveweb.page in the Chrome store](installation/install_requirements)</b>
-2. <b>[Add archiveweb.page to your Chrome](installation/add_extension)</b>
-3. <b>[Pin archiveweb.page to your Chrome extensions](installation/pin_extension)</b> 
+1. <b>[Find archiveweb.page in the Chrome store](install/install_requirements)</b>
+2. <b>[Add archiveweb.page to your Chrome](install/add_extension)</b>
+3. <b>[Pin archiveweb.page to your Chrome extensions](install/pin_extension)</b> 
 
 ![Installation GIF](/assets/images/installation/install.gif)
 

--- a/_es/instalacion.md
+++ b/_es/instalacion.md
@@ -15,9 +15,9 @@ Instalar archiveweb.page es similar a la instalación de cualquier otra extensi�
 3. Fijarla: a tu barra de extensiones. 
 
 ## Instrucciones (con imágenes)
-1. <b>[Encuentra archiveweb.page en la Chrome store.](/chrome)</b>
-2. <b>[Añadir archiveweb.page a tu Chrome]()</b>
-3. <b>[Fijar archiveweb.page a tus extensiones de Chrome](installation/pin_extension)</b> 
+1. <b>[Encuentra archiveweb.page en la Chrome store.](/instalación/chromestore)</b>
+2. <b>[Añadir archiveweb.page a tu Chrome](/instalación/agregar_extensión)</b>
+3. <b>[Fijar archiveweb.page a tus extensiones de Chrome](/instalación/fijar_extensión)</b> 
 
 ![Installation GIF](/assets/images/installation/install.gif)
 

--- a/_es/instalacion.md
+++ b/_es/instalacion.md
@@ -15,9 +15,9 @@ Instalar archiveweb.page es similar a la instalación de cualquier otra extensi�
 3. Fijarla: a tu barra de extensiones. 
 
 ## Instrucciones (con imágenes)
-1. <b>[Encuentra archiveweb.page en la Chrome store.](/instalación/chromestore)</b>
-2. <b>[Añadir archiveweb.page a tu Chrome](/instalación/agregar_extensión)</b>
-3. <b>[Fijar archiveweb.page a tus extensiones de Chrome](/instalación/fijar_extensión)</b> 
+1. <b>[Encuentra archiveweb.page en la Chrome store.](instalación/chromestore)</b>
+2. <b>[Añadir archiveweb.page a tu Chrome](instalación/agregar_extensión)</b>
+3. <b>[Fijar archiveweb.page a tus extensiones de Chrome](instalación/fijar_extensión)</b> 
 
 ![Installation GIF](/assets/images/installation/install.gif)
 


### PR DESCRIPTION
Hey! This PR fixes some broken links in the [How To Install archiveweb.page](https://archiveweb.page/en/install/) page in archiveweb.page documentation.